### PR TITLE
Updated 'tkinter' askopenfile method use to fix bug

### DIFF
--- a/sw1nhv2.4.py
+++ b/sw1nhv2.4.py
@@ -84,7 +84,7 @@ def checker():
 #get_input   
     print()
     print(Fore.LIGHTGREEN_EX + "Choose your combo:")
-    fileNameCombo = filedialog.askopenfile(parent=root, mode='rb', title='Choose your combo',filetype=(("txt", "*.txt"), ("All files", "*.txt")))
+    fileNameCombo = filedialog.askopenfile(parent=root, mode='rb', title='Choose your combo',filetypes=(("txt", "*.txt"), ("All files", "*.txt")))
     if fileNameCombo is None:
         print()
         print(Fore.RED + "Please select valid combo file!")


### PR DESCRIPTION
'tkinter' askopenfile() requires -filetypes (not -filetype) to run code

Bug below:
File "/home/runner/Python/main.py", line 87, in checker
    fileNameCombo = filedialog.askopenfile(parent=root, mode='rb', title='Choose your combo',filetype=(("txt", "*.txt"), ("All files", "*.txt")))

s = master.tk.call(self.command, *master._options(self.options)) _tkinter.TclError: bad option "-filetype": must be -defaultextension, -filetypes, -initialdir, -initialfile, -multiple, -parent, -title, or -typevariable